### PR TITLE
Lazy loading and caching for attributes set in `_loadData(..)`

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -403,7 +403,6 @@ class Album(
         self.parentTitle = data.attrib.get('parentTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.studio = data.attrib.get('studio')
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
 
@@ -434,6 +433,10 @@ class Album(
     @cached_data_property
     def subformats(self):
         return self.findItems(self._data, media.Subformat)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     def __iter__(self):
         for track in self.tracks():

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -59,7 +59,6 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus
 from typing import Any, Dict, List, Optional, TypeVar
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus
 from typing import Any, Dict, List, Optional, TypeVar
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -59,7 +59,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexPartialObject._loadData(self, data)
+        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -8,7 +8,7 @@ from urllib.parse import quote_plus
 from typing import Any, Dict, List, Optional, TypeVar
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -59,14 +59,12 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexPartialObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')
         self.distance = utils.cast(float, data.attrib.get('distance'))
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
-        self.images = self.findItems(data, media.Image)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = data.attrib.get('key', '')
         self.lastRatedAt = utils.toDatetime(data.attrib.get('lastRatedAt'))
@@ -75,7 +73,6 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         self.librarySectionKey = data.attrib.get('librarySectionKey')
         self.librarySectionTitle = data.attrib.get('librarySectionTitle')
         self.listType = 'audio'
-        self.moods = self.findItems(data, media.Mood)
         self.musicAnalysisVersion = utils.cast(int, data.attrib.get('musicAnalysisVersion'))
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.summary = data.attrib.get('summary')
@@ -87,6 +84,18 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self.viewCount = utils.cast(int, data.attrib.get('viewCount', 0))
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def images(self):
+        return self.findItems(self._data, media.Image)
+
+    @cached_data_property
+    def moods(self):
+        return self.findItems(self._data, media.Mood)
 
     def url(self, part):
         """ Returns the full URL for the audio item. Typically used for getting a specific track. """
@@ -205,18 +214,45 @@ class Artist(
         Audio._loadData(self, data)
         self.albumSort = utils.cast(int, data.attrib.get('albumSort', '-1'))
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
-        self.collections = self.findItems(data, media.Collection)
-        self.countries = self.findItems(data, media.Country)
-        self.genres = self.findItems(data, media.Genre)
-        self.guids = self.findItems(data, media.Guid)
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
-        self.labels = self.findItems(data, media.Label)
-        self.locations = self.listAttrs(data, 'path', etag='Location')
         self.rating = utils.cast(float, data.attrib.get('rating'))
-        self.similar = self.findItems(data, media.Similar)
-        self.styles = self.findItems(data, media.Style)
         self.theme = data.attrib.get('theme')
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def countries(self):
+        return self.findItems(self._data, media.Country)
+
+    @cached_data_property
+    def genres(self):
+        return self.findItems(self._data, media.Genre)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def locations(self):
+        return self.listAttrs(self._data, 'path', etag='Location')
+
+    @cached_data_property
+    def similar(self):
+        return self.findItems(self._data, media.Similar)
+
+    @cached_data_property
+    def styles(self):
+        return self.findItems(self._data, media.Style)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     def __iter__(self):
         for album in self.albums():
@@ -355,12 +391,7 @@ class Album(
         """ Load attribute values from Plex XML response. """
         Audio._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
-        self.collections = self.findItems(data, media.Collection)
-        self.formats = self.findItems(data, media.Format)
-        self.genres = self.findItems(data, media.Genre)
-        self.guids = self.findItems(data, media.Guid)
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
-        self.labels = self.findItems(data, media.Label)
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
         self.loudnessAnalysisVersion = utils.cast(int, data.attrib.get('loudnessAnalysisVersion'))
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
@@ -372,11 +403,37 @@ class Album(
         self.parentTitle = data.attrib.get('parentTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.studio = data.attrib.get('studio')
-        self.styles = self.findItems(data, media.Style)
-        self.subformats = self.findItems(data, media.Subformat)
         self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def formats(self):
+        return self.findItems(self._data, media.Format)
+
+    @cached_data_property
+    def genres(self):
+        return self.findItems(self._data, media.Genre)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def styles(self):
+        return self.findItems(self._data, media.Style)
+
+    @cached_data_property
+    def subformats(self):
+        return self.findItems(self._data, media.Subformat)
 
     def __iter__(self):
         for track in self.tracks():
@@ -495,11 +552,8 @@ class Track(
         Audio._loadData(self, data)
         Playable._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
-        self.chapters = self.findItems(data, media.Chapter)
         self.chapterSource = data.attrib.get('chapterSource')
-        self.collections = self.findItems(data, media.Collection)
         self.duration = utils.cast(int, data.attrib.get('duration'))
-        self.genres = self.findItems(data, media.Genre)
         self.grandparentArt = data.attrib.get('grandparentArt')
         self.grandparentGuid = data.attrib.get('grandparentGuid')
         self.grandparentKey = data.attrib.get('grandparentKey')
@@ -507,9 +561,6 @@ class Track(
         self.grandparentTheme = data.attrib.get('grandparentTheme')
         self.grandparentThumb = data.attrib.get('grandparentThumb')
         self.grandparentTitle = data.attrib.get('grandparentTitle')
-        self.guids = self.findItems(data, media.Guid)
-        self.labels = self.findItems(data, media.Label)
-        self.media = self.findItems(data, media.Media)
         self.originalTitle = data.attrib.get('originalTitle')
         self.parentGuid = data.attrib.get('parentGuid')
         self.parentIndex = utils.cast(int, data.attrib.get('parentIndex'))
@@ -524,6 +575,30 @@ class Track(
         self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def chapters(self):
+        return self.findItems(self._data, media.Chapter)
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def genres(self):
+        return self.findItems(self._data, media.Genre)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def media(self):
+        return self.findItems(self._data, media.Media)
 
     @property
     def locations(self):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -532,14 +532,6 @@ class PlexObject(metaclass=PlexObjectMeta):
             return float(value)
         return value
 
-    def _invalidateCachedProperties(self):
-        """Invalidate all cached data property values."""
-        cached_props = getattr(self.__class__, '_cached_data_properties', set())
-
-        for prop_name in cached_props:
-            if prop_name in self.__dict__:
-                del self.__dict__[prop_name]
-
     def _invalidateCacheAndLoadData(self, data):
         """Load attribute values from Plex XML response and invalidate cached properties."""
         old_data_id = id(getattr(self, '_data', None))
@@ -550,6 +542,14 @@ class PlexObject(metaclass=PlexObjectMeta):
             self._invalidateCachedProperties()
 
         self._loadData(data)
+
+    def _invalidateCachedProperties(self):
+        """Invalidate all cached data property values."""
+        cached_props = getattr(self.__class__, '_cached_data_properties', set())
+
+        for prop_name in cached_props:
+            if prop_name in self.__dict__:
+                del self.__dict__[prop_name]
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -809,9 +809,11 @@ class PlexPartialObject(PlexObject):
 
 
 class Playable:
-    """ This is a general place to store functions specific to media that is Playable.
+    """ This is a mixin to store functions specific to media that is Playable.
         Things were getting mixed up a bit when dealing with Shows, Season, Artists,
         Albums which are all not playable.
+
+        This class 
 
         Attributes:
             playlistItemID (int): Playlist item ID (only populated for :class:`~plexapi.playlist.Playlist` items).
@@ -988,7 +990,7 @@ class Playable:
 
 
 class PlexSession:
-    """ This is a general place to store functions specific to media that is a Plex Session.
+    """ This is a mixin to store functions specific to media that is a Plex Session.
 
         Attributes:
             live (bool): True if this is a live tv session.
@@ -1091,7 +1093,7 @@ class PlexSession:
 
 
 class PlexHistory:
-    """ This is a general place to store functions specific to media that is a Plex history item.
+    """ This is a mixin to store functions specific to media that is a Plex history item.
 
         Attributes:
             accountID (int): The associated :class:`~plexapi.server.SystemAccount` ID.

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -813,8 +813,6 @@ class Playable:
         Things were getting mixed up a bit when dealing with Shows, Season, Artists,
         Albums which are all not playable.
 
-        This class 
-
         Attributes:
             playlistItemID (int): Playlist item ID (only populated for :class:`~plexapi.playlist.Playlist` items).
             playQueueItemID (int): PlayQueue item ID (only populated for :class:`~plexapi.playlist.PlayQueue` items).
@@ -1005,10 +1003,7 @@ class PlexSession:
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         self.live = utils.cast(bool, data.attrib.get('live', '0'))
-        self.player = self.findItem(data, etag='Player')
-        self.session = self.findItem(data, etag='Session')
         self.sessionKey = utils.cast(int, data.attrib.get('sessionKey'))
-        self.transcodeSession = self.findItem(data, etag='TranscodeSession')
 
         user = data.find('User')
         self._username = user.attrib.get('title')

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1174,7 +1174,7 @@ class MediaContainer(
                 setattr(self, key, getattr(__iterable, key))
 
     def _loadData(self, data):
-        self._data = data
+        PlexPartialObject._loadData(self, data)
         self.allowSync = utils.cast(int, data.attrib.get('allowSync'))
         self.augmentationKey = data.attrib.get('augmentationKey')
         self.identifier = data.attrib.get('identifier')

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -537,7 +537,7 @@ class PlexObject(metaclass=PlexObjectMeta):
         cached_props = getattr(self.__class__, '_cached_data_properties', set())
 
         for prop_name in cached_props:
-            cache_name = f"_{prop_name}"
+            cache_name = prop_name
             if cache_name in self.__dict__:
                 del self.__dict__[cache_name]
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -89,7 +89,7 @@ class PlexObject(metaclass=PlexObjectMeta):
 
     def __init__(self, server, data, initpath=None, parent=None):
         self._server = server
-        PlexObject._loadData(self, data)
+        self._data = data
         self._initpath = initpath or self.key
         self._parent = weakref.ref(parent) if parent is not None else None
         self._details_key = None

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -537,9 +537,8 @@ class PlexObject(metaclass=PlexObjectMeta):
         cached_props = getattr(self.__class__, '_cached_data_properties', set())
 
         for prop_name in cached_props:
-            cache_name = prop_name
-            if cache_name in self.__dict__:
-                del self.__dict__[cache_name]
+            if prop_name in self.__dict__:
+                del self.__dict__[prop_name]
 
     def _loadData(self, data):
         """Load attribute values from Plex XML response and invalidate cached properties."""

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1174,7 +1174,7 @@ class MediaContainer(
                 setattr(self, key, getattr(__iterable, key))
 
     def _loadData(self, data):
-        PlexPartialObject._loadData(self, data)
+        PlexObject._loadData(self, data)
         self.allowSync = utils.cast(int, data.attrib.get('allowSync'))
         self.augmentationKey = data.attrib.get('augmentationKey')
         self.identifier = data.attrib.get('identifier')

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1013,10 +1013,33 @@ class PlexSession:
         self._userId = utils.cast(int, user.attrib.get('id'))
 
         # For backwards compatibility
-        self.players = [self.player] if self.player else []
-        self.sessions = [self.session] if self.session else []
-        self.transcodeSessions = [self.transcodeSession] if self.transcodeSession else []
         self.usernames = [self._username] if self._username else []
+        # `players`, `sessions`, and `transcodeSessions` are returned with properties
+        # to support lazy loading. See PR #1510
+
+    @cached_data_property
+    def player(self):
+        return self.findItem(self.data, etag='Player')
+
+    @cached_data_property
+    def session(self):
+        return self.findItem(self.data, etag='Session')
+
+    @cached_data_property
+    def transcodeSession(self):
+        return self.findItem(self.data, etag='TranscodeSession')
+
+    @property
+    def players(self):
+        return [self.player] if self.player else []
+
+    @property
+    def sessions(self):
+        return [self.session] if self.session else []
+
+    @property
+    def transcodeSessions(self):
+        return [self.transcodeSession] if self.transcodeSession else []
 
     @cached_property
     def user(self):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -987,7 +987,7 @@ class Playable:
         return self
 
 
-class PlexSession(object):
+class PlexSession:
     """ This is a general place to store functions specific to media that is a Plex Session.
 
         Attributes:
@@ -1067,7 +1067,7 @@ class PlexSession(object):
         return self._server.query(key, params=params)
 
 
-class PlexHistory(object):
+class PlexHistory:
     """ This is a general place to store functions specific to media that is a Plex history item.
 
         Attributes:

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -115,7 +115,7 @@ class PlexClient(PlexObject):
                 )
         else:
             client = data[0]
-        self._loadData(client)
+        self._invalidateCacheAndLoadData(client)
         return self
 
     def reload(self):

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -197,8 +197,7 @@ class PlexClient(PlexObject):
                 raise NotFound(message)
             else:
                 raise BadRequest(message)
-        data = utils.cleanXMLString(response.text).encode('utf8')
-        return ElementTree.fromstring(data) if data.strip() else None
+        return utils.parseXMLString(response.text)
 
     def sendCommand(self, command, proxy=None, **params):
         """ Convenience wrapper around :func:`~plexapi.client.PlexClient.query` to more easily

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -197,7 +197,8 @@ class PlexClient(PlexObject):
                 raise NotFound(message)
             else:
                 raise BadRequest(message)
-        return utils.parseXMLString(response.text)
+        data = utils.cleanXMLString(response.text).encode('utf8')
+        return ElementTree.fromstring(data) if data.strip() else None
 
     def sendCommand(self, command, proxy=None, **params):
         """ Convenience wrapper around :func:`~plexapi.client.PlexClient.query` to more easily

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -124,7 +124,7 @@ class PlexClient(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.deviceClass = data.attrib.get('deviceClass')
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.product = data.attrib.get('product')
@@ -606,7 +606,7 @@ class ClientTimeline(PlexObject):
     key = 'timeline/poll'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.address = data.attrib.get('address')
         self.audioStreamId = utils.cast(int, data.attrib.get('audioStreamId'))
         self.autoPlay = utils.cast(bool, data.attrib.get('autoPlay'))

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -124,7 +124,6 @@ class PlexClient(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.deviceClass = data.attrib.get('deviceClass')
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.product = data.attrib.get('product')
@@ -606,7 +605,7 @@ class ClientTimeline(PlexObject):
     key = 'timeline/poll'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.address = data.attrib.get('address')
         self.audioStreamId = utils.cast(int, data.attrib.get('audioStreamId'))
         self.autoPlay = utils.cast(bool, data.attrib.get('autoPlay'))

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -102,7 +102,6 @@ class Collection(
         self.title = data.attrib.get('title')
         self.titleSort = data.attrib.get('titleSort', self.title)
         self.type = data.attrib.get('type')
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self._items = None  # cache for self.items
@@ -120,6 +119,10 @@ class Collection(
     @cached_data_property
     def labels(self):
         return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     def __len__(self):  # pragma: no cover
         return len(self.items())

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import PlexPartialObject, cached_data_property
+from plexapi.base import PlexObject, PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, ManagedHub
 from plexapi.mixins import (
@@ -69,7 +69,7 @@ class Collection(
     TYPE = 'collection'
 
     def _loadData(self, data):
-        PlexPartialObject._loadData(self, data)
+        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -69,7 +69,7 @@ class Collection(
     TYPE = 'collection'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import PlexPartialObject
+from plexapi.base import PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, ManagedHub
 from plexapi.mixins import (
@@ -69,7 +69,7 @@ class Collection(
     TYPE = 'collection'
 
     def _loadData(self, data):
-        self._data = data
+        PlexPartialObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')
@@ -81,12 +81,9 @@ class Collection(
         self.collectionSort = utils.cast(int, data.attrib.get('collectionSort', '0'))
         self.content = data.attrib.get('content')
         self.contentRating = data.attrib.get('contentRating')
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
-        self.images = self.findItems(data, media.Image)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = data.attrib.get('key', '').replace('/children', '')  # FIX_BUG_50
-        self.labels = self.findItems(data, media.Label)
         self.lastRatedAt = utils.toDatetime(data.attrib.get('lastRatedAt'))
         self.librarySectionID = utils.cast(int, data.attrib.get('librarySectionID'))
         self.librarySectionKey = data.attrib.get('librarySectionKey')
@@ -111,6 +108,18 @@ class Collection(
         self._items = None  # cache for self.items
         self._section = None  # cache for self.section
         self._filters = None  # cache for self.filters
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def images(self):
+        return self.findItems(self._data, media.Image)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
 
     def __len__(self):  # pragma: no cover
         return len(self.items())

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import PlexObject, PlexPartialObject, cached_data_property
+from plexapi.base import PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, ManagedHub
 from plexapi.mixins import (

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2235,6 +2235,12 @@ class Hub(PlexObject):
 
     @cached_data_property
     def items(self):
+        if self.more and self.key:  # If there are more items to load, fetch them
+            items = self.fetchItems(self.key)
+            self.more = False
+            self.size = len(items)
+            return items
+        # Otherwise, all the data is in the initial _data XML response
         return self.findItems(self._data)
 
     def __len__(self):
@@ -2242,10 +2248,7 @@ class Hub(PlexObject):
 
     def reload(self):
         """ Reloads the hub to fetch all items in the hub. """
-        if self.more and self.key:
-            self.items = self.fetchItems(self.key)
-            self.more = False
-            self.size = len(self.items)
+        self._invalidateCachedProperties()
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this hub belongs to.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -39,7 +39,7 @@ class Library(PlexObject):
     key = '/library'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.identifier = data.attrib.get('identifier')
         self.mediaTagVersion = data.attrib.get('mediaTagVersion')
         self.title1 = data.attrib.get('title1')
@@ -432,7 +432,7 @@ class LibrarySection(PlexObject):
     """
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.agent = data.attrib.get('agent')
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))
         self.art = data.attrib.get('art')
@@ -2169,7 +2169,6 @@ class LibraryTimeline(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.size = utils.cast(int, data.attrib.get('size'))
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))
         self.art = data.attrib.get('art')
@@ -2198,7 +2197,6 @@ class Location(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.id = utils.cast(int, data.attrib.get('id'))
         self.path = data.attrib.get('path')
 
@@ -2224,7 +2222,6 @@ class Hub(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.context = data.attrib.get('context')
         self.hubKey = data.attrib.get('hubKey')
         self.hubIdentifier = data.attrib.get('hubIdentifier')
@@ -2286,7 +2283,6 @@ class LibraryMediaTag(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.count = utils.cast(int, data.attrib.get('count'))
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id'))
@@ -2675,7 +2671,7 @@ class FilteringType(PlexObject):
         return f"<{':'.join([p for p in [self.__class__.__name__, _type] if p])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.active = utils.cast(bool, data.attrib.get('active', '0'))
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
@@ -2873,7 +2869,7 @@ class FilteringFilter(PlexObject):
     TAG = 'Filter'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.filter = data.attrib.get('filter')
         self.filterType = data.attrib.get('filterType')
         self.key = data.attrib.get('key')
@@ -2899,7 +2895,6 @@ class FilteringSort(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.active = utils.cast(bool, data.attrib.get('active', '0'))
         self.activeDirection = data.attrib.get('activeDirection')
         self.default = data.attrib.get('default')
@@ -2924,7 +2919,6 @@ class FilteringField(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
@@ -2947,7 +2941,6 @@ class FilteringFieldType(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.type = data.attrib.get('type')
 
     @cached_data_property
@@ -2967,7 +2960,6 @@ class FilteringOperator(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
 
@@ -2990,7 +2982,6 @@ class FilterChoice(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.fastKey = data.attrib.get('fastKey')
         self.key = data.attrib.get('key')
         self.thumb = data.attrib.get('thumb')
@@ -3020,7 +3011,6 @@ class ManagedHub(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.deletable = utils.cast(bool, data.attrib.get('deletable', True))
         self.homeVisibility = data.attrib.get('homeVisibility', 'none')
         self.identifier = data.attrib.get('identifier')
@@ -3144,7 +3134,6 @@ class Folder(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
 
@@ -3185,7 +3174,6 @@ class FirstCharacter(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.size = data.attrib.get('size')
         self.title = data.attrib.get('title')
@@ -3206,7 +3194,7 @@ class Path(PlexObject):
     TAG = 'Path'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.home = utils.cast(bool, data.attrib.get('home'))
         self.key = data.attrib.get('key')
         self.network = utils.cast(bool, data.attrib.get('network'))
@@ -3236,7 +3224,7 @@ class File(PlexObject):
     TAG = 'File'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.key = data.attrib.get('key')
         self.path = data.attrib.get('path')
         self.title = data.attrib.get('title')
@@ -3285,7 +3273,7 @@ class Common(PlexObject):
     TAG = 'Common'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.contentRating = data.attrib.get('contentRating')
         self.editionTitle = data.attrib.get('editionTitle')
         self.grandparentRatingKey = utils.cast(int, data.attrib.get('grandparentRatingKey'))

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2247,7 +2247,7 @@ class Hub(PlexObject):
         return self.size
 
     def reload(self):
-        """ Reloads the hub to fetch all items in the hub. """
+        """ Delete cached data to allow reloading of hub items. """
         self._invalidateCachedProperties()
         if self._data is not None:
             self.more = utils.cast(bool, self._data.attrib.get('more'))

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -39,7 +39,7 @@ class Library(PlexObject):
     key = '/library'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.identifier = data.attrib.get('identifier')
         self.mediaTagVersion = data.attrib.get('mediaTagVersion')
         self.title1 = data.attrib.get('title1')
@@ -432,7 +432,7 @@ class LibrarySection(PlexObject):
     """
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.agent = data.attrib.get('agent')
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))
         self.art = data.attrib.get('art')
@@ -441,7 +441,6 @@ class LibrarySection(PlexObject):
         self.filters = utils.cast(bool, data.attrib.get('filters'))
         self.key = utils.cast(int, data.attrib.get('key'))
         self.language = data.attrib.get('language')
-        self.locations = self.listAttrs(data, 'path', etag='Location')
         self.refreshing = utils.cast(bool, data.attrib.get('refreshing'))
         self.scanner = data.attrib.get('scanner')
         self.thumb = data.attrib.get('thumb')
@@ -455,6 +454,10 @@ class LibrarySection(PlexObject):
         self._totalViewSize = None
         self._totalDuration = None
         self._totalStorage = None
+
+    @cached_data_property
+    def locations(self):
+        return self.listAttrs(self._data, 'path', etag='Location')
 
     @cached_property
     def totalSize(self):
@@ -2165,7 +2168,7 @@ class LibraryTimeline(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.size = utils.cast(int, data.attrib.get('size'))
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))
         self.art = data.attrib.get('art')
@@ -2194,7 +2197,7 @@ class Location(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = utils.cast(int, data.attrib.get('id'))
         self.path = data.attrib.get('path')
 
@@ -2220,7 +2223,7 @@ class Hub(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.context = data.attrib.get('context')
         self.hubKey = data.attrib.get('hubKey')
         self.hubIdentifier = data.attrib.get('hubIdentifier')
@@ -2869,7 +2872,7 @@ class FilteringFilter(PlexObject):
     TAG = 'Filter'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.filter = data.attrib.get('filter')
         self.filterType = data.attrib.get('filterType')
         self.key = data.attrib.get('key')
@@ -2895,7 +2898,7 @@ class FilteringSort(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.active = utils.cast(bool, data.attrib.get('active', '0'))
         self.activeDirection = data.attrib.get('activeDirection')
         self.default = data.attrib.get('default')
@@ -2920,7 +2923,7 @@ class FilteringField(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
@@ -2963,6 +2966,7 @@ class FilteringOperator(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
 
@@ -2985,7 +2989,7 @@ class FilterChoice(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.fastKey = data.attrib.get('fastKey')
         self.key = data.attrib.get('key')
         self.thumb = data.attrib.get('thumb')
@@ -3015,7 +3019,7 @@ class ManagedHub(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.deletable = utils.cast(bool, data.attrib.get('deletable', True))
         self.homeVisibility = data.attrib.get('homeVisibility', 'none')
         self.identifier = data.attrib.get('identifier')
@@ -3139,6 +3143,7 @@ class Folder(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')
 
@@ -3179,7 +3184,7 @@ class FirstCharacter(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.size = data.attrib.get('size')
         self.title = data.attrib.get('title')
@@ -3200,6 +3205,7 @@ class Path(PlexObject):
     TAG = 'Path'
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.home = utils.cast(bool, data.attrib.get('home'))
         self.key = data.attrib.get('key')
         self.network = utils.cast(bool, data.attrib.get('network'))
@@ -3229,6 +3235,7 @@ class File(PlexObject):
     TAG = 'File'
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.path = data.attrib.get('path')
         self.title = data.attrib.get('title')

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2249,6 +2249,9 @@ class Hub(PlexObject):
     def reload(self):
         """ Reloads the hub to fetch all items in the hub. """
         self._invalidateCachedProperties()
+        if self._data is not None:
+            self.more = utils.cast(bool, self._data.attrib.get('more'))
+            self.size = utils.cast(int, self._data.attrib.get('size'))
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this hub belongs to.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -546,6 +546,7 @@ class LibrarySection(PlexObject):
         self._server.library._loadSections()
         newLibrary = self._server.library.sectionByID(self.key)
         self.__dict__.update(newLibrary.__dict__)
+        self._invalidateCachedProperties()
         return self
 
     def edit(self, agent=None, **kwargs):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -141,7 +141,7 @@ class MediaPart(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.accessible = utils.cast(bool, data.attrib.get('accessible'))
         self.audioProfile = data.attrib.get('audioProfile')
         self.container = data.attrib.get('container')
@@ -271,7 +271,7 @@ class MediaPartStream(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.bitrate = utils.cast(int, data.attrib.get('bitrate'))
         self.codec = data.attrib.get('codec')
         self.decision = data.attrib.get('decision')
@@ -572,7 +572,7 @@ class TranscodeSession(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.audioChannels = utils.cast(int, data.attrib.get('audioChannels'))
         self.audioCodec = data.attrib.get('audioCodec')
         self.audioDecision = data.attrib.get('audioDecision')
@@ -613,7 +613,7 @@ class TranscodeJob(PlexObject):
     TAG = 'TranscodeJob'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.generatorID = data.attrib.get('generatorID')
         self.key = data.attrib.get('key')
         self.progress = data.attrib.get('progress')
@@ -632,7 +632,7 @@ class Optimized(PlexObject):
     TAG = 'Item'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = data.attrib.get('id')
         self.composite = data.attrib.get('composite')
         self.title = data.attrib.get('title')
@@ -670,7 +670,7 @@ class Conversion(PlexObject):
     TAG = 'Video'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.addedAt = data.attrib.get('addedAt')
         self.art = data.attrib.get('art')
         self.chapterSource = data.attrib.get('chapterSource')
@@ -746,7 +746,7 @@ class MediaTag(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id'))
         self.key = data.attrib.get('key')
@@ -957,7 +957,7 @@ class Guid(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = data.attrib.get('id')
 
 
@@ -975,7 +975,7 @@ class Image(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.alt = data.attrib.get('alt')
         self.type = data.attrib.get('type')
         self.url = data.attrib.get('url')
@@ -997,7 +997,7 @@ class Rating(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.image = data.attrib.get('image')
         self.type = data.attrib.get('type')
         self.value = utils.cast(float, data.attrib.get('value'))
@@ -1020,7 +1020,7 @@ class Review(PlexObject):
     TAG = 'Review'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id', 0))
         self.image = data.attrib.get('image')
@@ -1045,7 +1045,7 @@ class UltraBlurColors(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.bottomLeft = data.attrib.get('bottomLeft')
         self.bottomRight = data.attrib.get('bottomRight')
         self.topLeft = data.attrib.get('topLeft')
@@ -1066,7 +1066,7 @@ class BaseResource(PlexObject):
     """
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.provider = data.attrib.get('provider')
         self.ratingKey = data.attrib.get('ratingKey')
@@ -1141,7 +1141,7 @@ class Chapter(PlexObject):
         return f"<{':'.join([self.__class__.__name__, name, offsets])}>"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id', 0))
@@ -1175,7 +1175,7 @@ class Marker(PlexObject):
         return f"<{':'.join([self.__class__.__name__, name, offsets])}>"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
         self.final = utils.cast(bool, data.attrib.get('final'))
         self.id = utils.cast(int, data.attrib.get('id'))
@@ -1209,7 +1209,7 @@ class Field(PlexObject):
     TAG = 'Field'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.locked = utils.cast(bool, data.attrib.get('locked'))
         self.name = data.attrib.get('name')
 
@@ -1229,7 +1229,7 @@ class SearchResult(PlexObject):
         return f"<{':'.join([p for p in [self.__class__.__name__, name, score] if p])}>"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.guid = data.attrib.get('guid')
         self.lifespanEnded = data.attrib.get('lifespanEnded')
         self.name = data.attrib.get('name')
@@ -1251,7 +1251,7 @@ class Agent(PlexObject):
         return f"<{':'.join([p for p in [self.__class__.__name__, uid] if p])}>"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.hasAttribution = data.attrib.get('hasAttribution')
         self.hasPrefs = data.attrib.get('hasPrefs')
         self.identifier = data.attrib.get('identifier')
@@ -1259,6 +1259,7 @@ class Agent(PlexObject):
         self.primary = data.attrib.get('primary')
         self.shortIdentifier = self.identifier.rsplit('.', 1)[1]
 
+        # TODO: How should the cached data property be handled here?
         if 'mediaType' in self._initpath:
             self.languageCodes = self.listAttrs(data, 'code', etag='Language')
             self.mediaTypes = []
@@ -1331,7 +1332,7 @@ class Availability(PlexObject):
         return f'<{self.__class__.__name__}:{self.platform}:{self.offerType}>'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.country = data.attrib.get('country')
         self.offerType = data.attrib.get('offerType')
         self.platform = data.attrib.get('platform')

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1260,13 +1260,17 @@ class Agent(PlexObject):
         self.primary = data.attrib.get('primary')
         self.shortIdentifier = self.identifier.rsplit('.', 1)[1]
 
-        # TODO: How should the cached data property be handled here?
+    @cached_data_property
+    def languageCodes(self):
         if 'mediaType' in self._initpath:
-            self.languageCodes = self.listAttrs(data, 'code', etag='Language')
-            self.mediaTypes = []
-        else:
-            self.languageCodes = []
-            self.mediaTypes = self.findItems(data, cls=AgentMediaType)
+            return self.listAttrs(self._data, 'code', etag='Language')
+        return []
+
+    @cached_data_property
+    def mediaTypes(self):
+        if 'mediaType' not in self._initpath:
+            return self.findItems(self._data, cls=AgentMediaType)
+        return []
 
     @property
     @deprecated('use "languageCodes" instead')

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -526,6 +526,7 @@ class Session(PlexObject):
     TAG = 'Session'
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.id = data.attrib.get('id')
         self.bandwidth = utils.cast(int, data.attrib.get('bandwidth'))
         self.location = data.attrib.get('location')
@@ -1295,6 +1296,7 @@ class AgentMediaType(Agent):
         return f"<{':'.join([p for p in [self.__class__.__name__, uid] if p])}>"
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.mediaType = utils.cast(int, data.attrib.get('mediaType'))
         self.name = data.attrib.get('name')
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -51,7 +51,6 @@ class Media(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.aspectRatio = utils.cast(float, data.attrib.get('aspectRatio'))
         self.audioChannels = utils.cast(int, data.attrib.get('audioChannels'))
         self.audioCodec = data.attrib.get('audioCodec')
@@ -141,7 +140,6 @@ class MediaPart(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.accessible = utils.cast(bool, data.attrib.get('accessible'))
         self.audioProfile = data.attrib.get('audioProfile')
         self.container = data.attrib.get('container')
@@ -271,7 +269,6 @@ class MediaPartStream(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.bitrate = utils.cast(int, data.attrib.get('bitrate'))
         self.codec = data.attrib.get('codec')
         self.decision = data.attrib.get('decision')
@@ -526,7 +523,7 @@ class Session(PlexObject):
     TAG = 'Session'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.id = data.attrib.get('id')
         self.bandwidth = utils.cast(int, data.attrib.get('bandwidth'))
         self.location = data.attrib.get('location')
@@ -573,7 +570,6 @@ class TranscodeSession(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.audioChannels = utils.cast(int, data.attrib.get('audioChannels'))
         self.audioCodec = data.attrib.get('audioCodec')
         self.audioDecision = data.attrib.get('audioDecision')
@@ -614,7 +610,7 @@ class TranscodeJob(PlexObject):
     TAG = 'TranscodeJob'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.generatorID = data.attrib.get('generatorID')
         self.key = data.attrib.get('key')
         self.progress = data.attrib.get('progress')
@@ -633,7 +629,7 @@ class Optimized(PlexObject):
     TAG = 'Item'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.id = data.attrib.get('id')
         self.composite = data.attrib.get('composite')
         self.title = data.attrib.get('title')
@@ -671,7 +667,7 @@ class Conversion(PlexObject):
     TAG = 'Video'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.addedAt = data.attrib.get('addedAt')
         self.art = data.attrib.get('art')
         self.chapterSource = data.attrib.get('chapterSource')
@@ -747,7 +743,6 @@ class MediaTag(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id'))
         self.key = data.attrib.get('key')
@@ -958,7 +953,6 @@ class Guid(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.id = data.attrib.get('id')
 
 
@@ -976,7 +970,6 @@ class Image(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.alt = data.attrib.get('alt')
         self.type = data.attrib.get('type')
         self.url = data.attrib.get('url')
@@ -998,7 +991,6 @@ class Rating(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.image = data.attrib.get('image')
         self.type = data.attrib.get('type')
         self.value = utils.cast(float, data.attrib.get('value'))
@@ -1021,7 +1013,7 @@ class Review(PlexObject):
     TAG = 'Review'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id', 0))
         self.image = data.attrib.get('image')
@@ -1046,7 +1038,6 @@ class UltraBlurColors(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.bottomLeft = data.attrib.get('bottomLeft')
         self.bottomRight = data.attrib.get('bottomRight')
         self.topLeft = data.attrib.get('topLeft')
@@ -1067,7 +1058,7 @@ class BaseResource(PlexObject):
     """
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.key = data.attrib.get('key')
         self.provider = data.attrib.get('provider')
         self.ratingKey = data.attrib.get('ratingKey')
@@ -1142,7 +1133,7 @@ class Chapter(PlexObject):
         return f"<{':'.join([self.__class__.__name__, name, offsets])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
         self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id', 0))
@@ -1176,7 +1167,7 @@ class Marker(PlexObject):
         return f"<{':'.join([self.__class__.__name__, name, offsets])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
         self.final = utils.cast(bool, data.attrib.get('final'))
         self.id = utils.cast(int, data.attrib.get('id'))
@@ -1210,7 +1201,7 @@ class Field(PlexObject):
     TAG = 'Field'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.locked = utils.cast(bool, data.attrib.get('locked'))
         self.name = data.attrib.get('name')
 
@@ -1230,7 +1221,7 @@ class SearchResult(PlexObject):
         return f"<{':'.join([p for p in [self.__class__.__name__, name, score] if p])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.guid = data.attrib.get('guid')
         self.lifespanEnded = data.attrib.get('lifespanEnded')
         self.name = data.attrib.get('name')
@@ -1252,7 +1243,7 @@ class Agent(PlexObject):
         return f"<{':'.join([p for p in [self.__class__.__name__, uid] if p])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.hasAttribution = data.attrib.get('hasAttribution')
         self.hasPrefs = data.attrib.get('hasPrefs')
         self.identifier = data.attrib.get('identifier')
@@ -1300,7 +1291,7 @@ class AgentMediaType(Agent):
         return f"<{':'.join([p for p in [self.__class__.__name__, uid] if p])}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.mediaType = utils.cast(int, data.attrib.get('mediaType'))
         self.name = data.attrib.get('name')
 
@@ -1338,7 +1329,7 @@ class Availability(PlexObject):
         return f'<{self.__class__.__name__}:{self.platform}:{self.offerType}>'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.country = data.attrib.get('country')
         self.offerType = data.attrib.get('offerType')
         self.platform = data.attrib.get('platform')

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -259,8 +259,7 @@ class MyPlexAccount(PlexObject):
             return response.json()
         elif 'text/plain' in response.headers.get('Content-Type', ''):
             return response.text.strip()
-        data = utils.cleanXMLString(response.text).encode('utf8')
-        return ElementTree.fromstring(data) if data.strip() else None
+        return utils.parseXMLString(response.text)
 
     def ping(self):
         """ Ping the Plex.tv API.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -223,7 +223,7 @@ class MyPlexAccount(PlexObject):
     def _reload(self, key=None, **kwargs):
         """ Perform the actual reload. """
         data = self.query(self.key)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self
 
     def _headers(self, **kwargs):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -144,7 +144,6 @@ class MyPlexAccount(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self._token = logfilter.add_secret(data.attrib.get('authToken'))
         self._webhooks = []
 
@@ -1215,7 +1214,6 @@ class MyPlexUser(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.friend = self._initpath == self.key
         self.allowCameraUpload = utils.cast(bool, data.attrib.get('allowCameraUpload'))
         self.allowChannels = utils.cast(bool, data.attrib.get('allowChannels'))
@@ -1295,7 +1293,6 @@ class MyPlexInvite(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.createdAt = utils.toDatetime(data.attrib.get('createdAt'))
         self.email = data.attrib.get('email')
         self.friend = utils.cast(bool, data.attrib.get('friend'))
@@ -1329,7 +1326,7 @@ class Section(PlexObject):
     TAG = 'Section'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.id = utils.cast(int, data.attrib.get('id'))
         self.key = utils.cast(int, data.attrib.get('key'))
         self.shared = utils.cast(bool, data.attrib.get('shared', '0'))
@@ -1368,7 +1365,6 @@ class MyPlexServerShare(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.id = utils.cast(int, data.attrib.get('id'))
         self.accountID = utils.cast(int, data.attrib.get('accountID'))
         self.serverId = utils.cast(int, data.attrib.get('serverId'))
@@ -1452,7 +1448,7 @@ class MyPlexResource(PlexObject):
     DEFAULT_SCHEME_ORDER = ['https', 'http']
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.accessToken = logfilter.add_secret(data.attrib.get('accessToken'))
         self.clientIdentifier = data.attrib.get('clientIdentifier')
         self.createdAt = utils.toDatetime(data.attrib.get('createdAt'), "%Y-%m-%dT%H:%M:%SZ")
@@ -1573,7 +1569,7 @@ class ResourceConnection(PlexObject):
     TAG = 'connection'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.address = data.attrib.get('address')
         self.ipv6 = utils.cast(bool, data.attrib.get('IPv6'))
         self.local = utils.cast(bool, data.attrib.get('local'))
@@ -1616,7 +1612,7 @@ class MyPlexDevice(PlexObject):
     key = 'https://plex.tv/devices.xml'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.name = data.attrib.get('name')
         self.publicAddress = data.attrib.get('publicAddress')
         self.product = data.attrib.get('product')
@@ -1960,7 +1956,7 @@ class AccountOptOut(PlexObject):
     CHOICES = {'opt_in', 'opt_out', 'opt_out_managed'}
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.key = data.attrib.get('key')
         self.value = data.attrib.get('value')
 
@@ -2019,7 +2015,7 @@ class UserState(PlexObject):
         return f'<{self.__class__.__name__}:{self.ratingKey}>'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.lastViewedAt = utils.toDatetime(data.attrib.get('lastViewedAt'))
         self.ratingKey = data.attrib.get('ratingKey')
         self.type = data.attrib.get('type')
@@ -2049,7 +2045,7 @@ class GeoLocation(PlexObject):
     TAG = 'location'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.city = data.attrib.get('city')
         self.code = data.attrib.get('code')
         self.continentCode = data.attrib.get('continent_code')

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -259,7 +259,8 @@ class MyPlexAccount(PlexObject):
             return response.json()
         elif 'text/plain' in response.headers.get('Content-Type', ''):
             return response.text.strip()
-        return utils.parseXMLString(response.text)
+        data = utils.cleanXMLString(response.text).encode('utf8')
+        return ElementTree.fromstring(data) if data.strip() else None
 
     def ping(self):
         """ Ping the Plex.tv API.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1329,7 +1329,7 @@ class Section(PlexObject):
     TAG = 'Section'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = utils.cast(int, data.attrib.get('id'))
         self.key = utils.cast(int, data.attrib.get('key'))
         self.shared = utils.cast(bool, data.attrib.get('shared', '0'))
@@ -1368,7 +1368,7 @@ class MyPlexServerShare(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = utils.cast(int, data.attrib.get('id'))
         self.accountID = utils.cast(int, data.attrib.get('accountID'))
         self.serverId = utils.cast(int, data.attrib.get('serverId'))
@@ -1573,7 +1573,7 @@ class ResourceConnection(PlexObject):
     TAG = 'connection'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.address = data.attrib.get('address')
         self.ipv6 = utils.cast(bool, data.attrib.get('IPv6'))
         self.local = utils.cast(bool, data.attrib.get('local'))
@@ -2047,7 +2047,7 @@ class GeoLocation(PlexObject):
     TAG = 'location'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.city = data.attrib.get('city')
         self.code = data.attrib.get('code')
         self.continentCode = data.attrib.get('continent_code')

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1960,6 +1960,7 @@ class AccountOptOut(PlexObject):
     CHOICES = {'opt_in', 'opt_out', 'opt_out_managed'}
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.key = data.attrib.get('key')
         self.value = data.attrib.get('value')
 
@@ -2018,6 +2019,7 @@ class UserState(PlexObject):
         return f'<{self.__class__.__name__}:{self.ratingKey}>'
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.lastViewedAt = utils.toDatetime(data.attrib.get('lastViewedAt'))
         self.ratingKey = data.attrib.get('ratingKey')
         self.type = data.attrib.get('type')

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils, video
-from plexapi.base import Playable, PlexPartialObject, PlexSession
+from plexapi.base import Playable, PlexPartialObject, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     RatingMixin,
@@ -56,9 +56,7 @@ class Photoalbum(
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.composite = data.attrib.get('composite')
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
-        self.images = self.findItems(data, media.Image)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = data.attrib.get('key', '').replace('/children', '')  # FIX_BUG_50
         self.lastRatedAt = utils.toDatetime(data.attrib.get('lastRatedAt'))
@@ -74,6 +72,14 @@ class Photoalbum(
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def images(self):
+        return self.findItems(self._data, media.Image)
 
     def album(self, title):
         """ Returns the :class:`~plexapi.photo.Photoalbum` that matches the specified title.
@@ -205,9 +211,7 @@ class Photo(
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.createdAtAccuracy = data.attrib.get('createdAtAccuracy')
         self.createdAtTZOffset = utils.cast(int, data.attrib.get('createdAtTZOffset'))
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
-        self.images = self.findItems(data, media.Image)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = data.attrib.get('key', '')
         self.lastRatedAt = utils.toDatetime(data.attrib.get('lastRatedAt'))
@@ -215,7 +219,6 @@ class Photo(
         self.librarySectionKey = data.attrib.get('librarySectionKey')
         self.librarySectionTitle = data.attrib.get('librarySectionTitle')
         self.listType = 'photo'
-        self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.parentGuid = data.attrib.get('parentGuid')
         self.parentIndex = utils.cast(int, data.attrib.get('parentIndex'))
@@ -226,7 +229,6 @@ class Photo(
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.summary = data.attrib.get('summary')
-        self.tags = self.findItems(data, media.Tag)
         self.thumb = data.attrib.get('thumb')
         self.title = data.attrib.get('title')
         self.titleSort = data.attrib.get('titleSort', self.title)
@@ -234,6 +236,22 @@ class Photo(
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def images(self):
+        return self.findItems(self._data, media.Image)
+
+    @cached_data_property
+    def media(self):
+        return self.findItems(self._data, media.Media)
+
+    @cached_data_property
+    def tags(self):
+        return self.findItems(self._data, media.Tag)
 
     def _prettyfilename(self):
         """ Returns a filename for use in download. """

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils, video
-from plexapi.base import Playable, PlexPartialObject, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     RatingMixin,
@@ -53,6 +53,7 @@ class Photoalbum(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.composite = data.attrib.get('composite')
@@ -207,6 +208,7 @@ class Photo(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         Playable._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.createdAtAccuracy = data.attrib.get('createdAtAccuracy')

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils, video
-from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexPartialObject, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     RatingMixin,

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -53,7 +53,6 @@ class Photoalbum(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.composite = data.attrib.get('composite')
@@ -208,7 +207,6 @@ class Photo(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         Playable._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.createdAtAccuracy = data.attrib.get('createdAtAccuracy')

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus, unquote
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject
+from plexapi.base import Playable, PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, MusicSection
 from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin, PlaylistEditMixins
@@ -60,7 +60,6 @@ class Playlist(
         self.content = data.attrib.get('content')
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.durationInSeconds = utils.cast(int, data.attrib.get('durationInSeconds'))
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
         self.icon = data.attrib.get('icon')
         self.key = data.attrib.get('key', '').replace('/items', '')  # FIX_BUG_50
@@ -80,6 +79,10 @@ class Playlist(
         self._items = None  # cache for self.items
         self._section = None  # cache for self.section
         self._filters = None  # cache for self.filters
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
 
     def __len__(self):  # pragma: no cover
         return len(self.items())

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus, unquote
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexObject, PlexPartialObject, cached_data_property
+from plexapi.base import Playable, PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, MusicSection
 from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin, PlaylistEditMixins

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus, unquote
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, cached_data_property
+from plexapi.base import Playable, PlexObject, PlexPartialObject, cached_data_property
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, MusicSection
 from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin, PlaylistEditMixins
@@ -53,6 +53,7 @@ class Playlist(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         Playable._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -53,7 +53,6 @@ class Playlist(
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         Playable._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -36,7 +36,7 @@ class PlayQueue(PlexObject):
     TYPE = "playqueue"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.identifier = data.attrib.get("identifier")
         self.mediaTagPrefix = data.attrib.get("mediaTagPrefix")
         self.mediaTagVersion = utils.cast(int, data.attrib.get("mediaTagVersion"))

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -2,7 +2,7 @@
 from urllib.parse import quote_plus
 
 from plexapi import utils
-from plexapi.base import PlexObject
+from plexapi.base import PlexObject, cached_data_property
 from plexapi.exceptions import BadRequest
 
 
@@ -36,7 +36,7 @@ class PlayQueue(PlexObject):
     TYPE = "playqueue"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.identifier = data.attrib.get("identifier")
         self.mediaTagPrefix = data.attrib.get("mediaTagPrefix")
         self.mediaTagVersion = utils.cast(int, data.attrib.get("mediaTagVersion"))
@@ -62,8 +62,11 @@ class PlayQueue(PlexObject):
         )
         self.playQueueVersion = utils.cast(int, data.attrib.get("playQueueVersion"))
         self.size = utils.cast(int, data.attrib.get("size", 0))
-        self.items = self.findItems(data)
         self.selectedItem = self[self.playQueueSelectedItemOffset]
+
+    @cached_data_property
+    def items(self):
+        return self.findItems(self._data)
 
     def __getitem__(self, key):
         if not self.items:

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -257,7 +257,7 @@ class PlayQueue(PlexObject):
 
         path = f"/playQueues/{self.playQueueID}{utils.joinArgs(args)}"
         data = self._server.query(path, method=self._server._session.put)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self
 
     def moveItem(self, item, after=None, refresh=True):
@@ -286,7 +286,7 @@ class PlayQueue(PlexObject):
 
         path = f"/playQueues/{self.playQueueID}/items/{item.playQueueItemID}/move{utils.joinArgs(args)}"
         data = self._server.query(path, method=self._server._session.put)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self
 
     def removeItem(self, item, refresh=True):
@@ -304,19 +304,19 @@ class PlayQueue(PlexObject):
 
         path = f"/playQueues/{self.playQueueID}/items/{item.playQueueItemID}"
         data = self._server.query(path, method=self._server._session.delete)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self
 
     def clear(self):
         """Remove all items from the PlayQueue."""
         path = f"/playQueues/{self.playQueueID}/items"
         data = self._server.query(path, method=self._server._session.delete)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self
 
     def refresh(self):
         """Refresh the PlayQueue from the Plex server."""
         path = f"/playQueues/{self.playQueueID}"
         data = self._server.query(path, method=self._server._session.get)
-        self._loadData(data)
+        self._invalidateCacheAndLoadData(data)
         return self

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -768,8 +768,7 @@ class PlexServer(PlexObject):
                 raise NotFound(message)
             else:
                 raise BadRequest(message)
-        data = utils.cleanXMLString(response.text).encode('utf8')
-        return ElementTree.fromstring(data) if data.strip() else None
+        return utils.parseXMLString(response.text)
 
     def search(self, query, mediatype=None, limit=None, sectionId=None):
         """ Returns a list of media items or filter categories from the resulting

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -118,7 +118,6 @@ class PlexServer(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.allowCameraUpload = utils.cast(bool, data.attrib.get('allowCameraUpload'))
         self.allowChannelAccess = utils.cast(bool, data.attrib.get('allowChannelAccess'))
         self.allowMediaDeletion = utils.cast(bool, data.attrib.get('allowMediaDeletion'))
@@ -1093,7 +1092,7 @@ class Account(PlexObject):
     key = '/myplex/account'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.authToken = data.attrib.get('authToken')
         self.username = data.attrib.get('username')
         self.mappingState = data.attrib.get('mappingState')
@@ -1114,7 +1113,7 @@ class Activity(PlexObject):
     key = '/activities'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.cancellable = utils.cast(bool, data.attrib.get('cancellable'))
         self.progress = utils.cast(int, data.attrib.get('progress'))
         self.title = data.attrib.get('title')
@@ -1129,7 +1128,7 @@ class Release(PlexObject):
     key = '/updater/status'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.download_key = data.attrib.get('key')
         self.version = data.attrib.get('version')
         self.added = data.attrib.get('added')
@@ -1155,7 +1154,7 @@ class SystemAccount(PlexObject):
     TAG = 'Account'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.autoSelectAudio = utils.cast(bool, data.attrib.get('autoSelectAudio'))
         self.defaultAudioLanguage = data.attrib.get('defaultAudioLanguage')
         self.defaultSubtitleLanguage = data.attrib.get('defaultSubtitleLanguage')
@@ -1184,7 +1183,7 @@ class SystemDevice(PlexObject):
     TAG = 'Device'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.clientIdentifier = data.attrib.get('clientIdentifier')
         self.createdAt = utils.toDatetime(data.attrib.get('createdAt'))
         self.id = utils.cast(int, data.attrib.get('id'))
@@ -1210,7 +1209,7 @@ class StatisticsBandwidth(PlexObject):
     TAG = 'StatisticsBandwidth'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.accountID = utils.cast(int, data.attrib.get('accountID'))
         self.at = utils.toDatetime(data.attrib.get('at'))
         self.bytes = utils.cast(int, data.attrib.get('bytes'))
@@ -1252,7 +1251,7 @@ class StatisticsResources(PlexObject):
     TAG = 'StatisticsResources'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.at = utils.toDatetime(data.attrib.get('at'))
         self.hostCpuUtilization = utils.cast(float, data.attrib.get('hostCpuUtilization'))
         self.hostMemoryUtilization = utils.cast(float, data.attrib.get('hostMemoryUtilization'))
@@ -1280,7 +1279,7 @@ class ButlerTask(PlexObject):
     TAG = 'ButlerTask'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.description = data.attrib.get('description')
         self.enabled = utils.cast(bool, data.attrib.get('enabled'))
         self.interval = utils.cast(int, data.attrib.get('interval'))
@@ -1302,7 +1301,7 @@ class Identity(PlexObject):
         return f"<{self.__class__.__name__}:{self.machineIdentifier}>"
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.claimed = utils.cast(bool, data.attrib.get('claimed'))
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.version = data.attrib.get('version')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -118,7 +118,7 @@ class PlexServer(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         self.allowCameraUpload = utils.cast(bool, data.attrib.get('allowCameraUpload'))
         self.allowChannelAccess = utils.cast(bool, data.attrib.get('allowChannelAccess'))
         self.allowMediaDeletion = utils.cast(bool, data.attrib.get('allowMediaDeletion'))
@@ -1093,7 +1093,7 @@ class Account(PlexObject):
     key = '/myplex/account'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.authToken = data.attrib.get('authToken')
         self.username = data.attrib.get('username')
         self.mappingState = data.attrib.get('mappingState')
@@ -1114,7 +1114,7 @@ class Activity(PlexObject):
     key = '/activities'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.cancellable = utils.cast(bool, data.attrib.get('cancellable'))
         self.progress = utils.cast(int, data.attrib.get('progress'))
         self.title = data.attrib.get('title')
@@ -1154,7 +1154,7 @@ class SystemAccount(PlexObject):
     TAG = 'Account'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.autoSelectAudio = utils.cast(bool, data.attrib.get('autoSelectAudio'))
         self.defaultAudioLanguage = data.attrib.get('defaultAudioLanguage')
         self.defaultSubtitleLanguage = data.attrib.get('defaultSubtitleLanguage')
@@ -1183,7 +1183,7 @@ class SystemDevice(PlexObject):
     TAG = 'Device'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.clientIdentifier = data.attrib.get('clientIdentifier')
         self.createdAt = utils.toDatetime(data.attrib.get('createdAt'))
         self.id = utils.cast(int, data.attrib.get('id'))
@@ -1209,7 +1209,7 @@ class StatisticsBandwidth(PlexObject):
     TAG = 'StatisticsBandwidth'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.accountID = utils.cast(int, data.attrib.get('accountID'))
         self.at = utils.toDatetime(data.attrib.get('at'))
         self.bytes = utils.cast(int, data.attrib.get('bytes'))
@@ -1251,7 +1251,7 @@ class StatisticsResources(PlexObject):
     TAG = 'StatisticsResources'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.at = utils.toDatetime(data.attrib.get('at'))
         self.hostCpuUtilization = utils.cast(float, data.attrib.get('hostCpuUtilization'))
         self.hostMemoryUtilization = utils.cast(float, data.attrib.get('hostMemoryUtilization'))
@@ -1279,7 +1279,7 @@ class ButlerTask(PlexObject):
     TAG = 'ButlerTask'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.description = data.attrib.get('description')
         self.enabled = utils.cast(bool, data.attrib.get('enabled'))
         self.interval = utils.cast(int, data.attrib.get('interval'))
@@ -1301,7 +1301,7 @@ class Identity(PlexObject):
         return f"<{self.__class__.__name__}:{self.machineIdentifier}>"
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.claimed = utils.cast(bool, data.attrib.get('claimed'))
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.version = data.attrib.get('version')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1129,6 +1129,7 @@ class Release(PlexObject):
     key = '/updater/status'
 
     def _loadData(self, data):
+        PlexObject._loadData(self, data)
         self.download_key = data.attrib.get('key')
         self.version = data.attrib.get('version')
         self.added = data.attrib.get('added')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -768,7 +768,8 @@ class PlexServer(PlexObject):
                 raise NotFound(message)
             else:
                 raise BadRequest(message)
-        return utils.parseXMLString(response.text)
+        data = utils.cleanXMLString(response.text).encode('utf8')
+        return ElementTree.fromstring(data) if data.strip() else None
 
     def search(self, query, mediatype=None, limit=None, sectionId=None):
         """ Returns a list of media items or filter categories from the resulting

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -34,7 +34,6 @@ class Settings(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         for elem in data:
             id = utils.lowerFirst(elem.attrib['id'])
             if id in self._settings:
@@ -113,7 +112,6 @@ class Setting(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.type = data.attrib.get('type')
         self.advanced = utils.cast(bool, data.attrib.get('advanced'))
         self.default = self._cast(data.attrib.get('default'))

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -113,6 +113,7 @@ class Setting(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
+        PlexObject._loadData(self, data)
         self.type = data.attrib.get('type')
         self.advanced = utils.cast(bool, data.attrib.get('advanced'))
         self.default = self._cast(data.attrib.get('default'))

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -34,7 +34,7 @@ class Settings(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexObject._loadData(self, data)
         for elem in data:
             id = utils.lowerFirst(elem.attrib['id'])
             if id in self._settings:

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -37,7 +37,7 @@ class Settings(PlexObject):
         for elem in data:
             id = utils.lowerFirst(elem.attrib['id'])
             if id in self._settings:
-                self._settings[id]._loadData(elem)
+                self._settings[id]._invalidateCacheAndLoadData(elem)
                 continue
             self._settings[id] = Setting(self._server, elem, self._initpath)
 

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -5,7 +5,6 @@ from plexapi import CONFIG, X_PLEX_IDENTIFIER, TIMEOUT
 from plexapi.client import PlexClient
 from plexapi.exceptions import BadRequest
 from plexapi.playqueue import PlayQueue
-from plexapi.base import PlexObject
 
 
 class PlexSonosClient(PlexClient):

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -48,7 +48,6 @@ class PlexSonosClient(PlexClient):
     """
 
     def __init__(self, account, data, timeout=None):
-        PlexObject._loadData(self, data)
         self.deviceClass = data.attrib.get("deviceClass")
         self.machineIdentifier = data.attrib.get("machineIdentifier")
         self.product = data.attrib.get("product")

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -5,6 +5,7 @@ from plexapi import CONFIG, X_PLEX_IDENTIFIER, TIMEOUT
 from plexapi.client import PlexClient
 from plexapi.exceptions import BadRequest
 from plexapi.playqueue import PlayQueue
+from plexapi.base import PlexObject
 
 
 class PlexSonosClient(PlexClient):
@@ -47,7 +48,7 @@ class PlexSonosClient(PlexClient):
     """
 
     def __init__(self, account, data, timeout=None):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.deviceClass = data.attrib.get("deviceClass")
         self.machineIdentifier = data.attrib.get("machineIdentifier")
         self.product = data.attrib.get("product")

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -63,7 +63,7 @@ class SyncItem(PlexObject):
         self.clientIdentifier = clientIdentifier
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.id = plexapi.utils.cast(int, data.attrib.get('id'))
         self.version = plexapi.utils.cast(int, data.attrib.get('version'))
         self.rootTitle = data.attrib.get('rootTitle')
@@ -118,7 +118,7 @@ class SyncList(PlexObject):
     TAG = 'SyncList'
 
     def _loadData(self, data):
-        PlexObject._loadData(self, data)
+        """ Load attribute values from Plex XML response. """
         self.clientId = data.attrib.get('clientIdentifier')
         self.items = []
 

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -63,7 +63,7 @@ class SyncItem(PlexObject):
         self.clientIdentifier = clientIdentifier
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.id = plexapi.utils.cast(int, data.attrib.get('id'))
         self.version = plexapi.utils.cast(int, data.attrib.get('version'))
         self.rootTitle = data.attrib.get('rootTitle')
@@ -118,7 +118,7 @@ class SyncList(PlexObject):
     TAG = 'SyncList'
 
     def _loadData(self, data):
-        self._data = data
+        PlexObject._loadData(self, data)
         self.clientId = data.attrib.get('clientIdentifier')
         self.items = []
 

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -18,6 +18,8 @@ from hashlib import sha1
 from threading import Event, Thread
 from urllib.parse import quote
 
+from xml.etree import ElementTree
+
 import requests
 from requests.status_codes import _codes as codes
 
@@ -718,3 +720,13 @@ _illegal_XML_re = re.compile(fr'[{"".join(_illegal_XML_ranges)}]')
 
 def cleanXMLString(s):
     return _illegal_XML_re.sub('', s)
+
+
+def parseXMLString(s: str):
+    """ Parse an XML string and return an ElementTree object. """
+    if not s.strip():
+        return None
+    try:  # Attempt to parse the string as-is without cleaning (which is expensive)
+        return ElementTree.fromstring(s.encode('utf-8'))
+    except ElementTree.ParseError:  # If it fails, clean the string and try again
+        return ElementTree.fromstring(cleanXMLString(s).encode('utf-8'))

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -18,8 +18,6 @@ from hashlib import sha1
 from threading import Event, Thread
 from urllib.parse import quote
 
-from xml.etree import ElementTree
-
 import requests
 from requests.status_codes import _codes as codes
 
@@ -720,13 +718,3 @@ _illegal_XML_re = re.compile(fr'[{"".join(_illegal_XML_ranges)}]')
 
 def cleanXMLString(s):
     return _illegal_XML_re.sub('', s)
-
-
-def parseXMLString(s: str):
-    """ Parse an XML string and return an ElementTree object. """
-    if not s.strip():
-        return None
-    try:  # Attempt to parse the string as-is without cleaning (which is expensive)
-        return ElementTree.fromstring(s.encode('utf-8'))
-    except ElementTree.ParseError:  # If it fails, clean the string and try again
-        return ElementTree.fromstring(cleanXMLString(s).encode('utf-8'))

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -1055,7 +1055,6 @@ class Episode(
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
         self.sourceURI = data.attrib.get('source')  # remote playlist item
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
 
@@ -1109,6 +1108,10 @@ class Episode(
     @cached_data_property
     def writers(self):
         return self.findItems(self._data, media.Writer)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     @cached_property
     def parentKey(self):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
+from plexapi.base import Playable, PlexObject, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -48,7 +48,7 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexPartialObject._loadData(self, data)
+        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession, cached_data_property
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -48,13 +48,11 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._data = data
+        PlexPartialObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')
-        self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
-        self.images = self.findItems(data, media.Image)
         self.key = data.attrib.get('key', '')
         self.lastRatedAt = utils.toDatetime(data.attrib.get('lastRatedAt'))
         self.lastViewedAt = utils.toDatetime(data.attrib.get('lastViewedAt'))
@@ -72,6 +70,14 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self.viewCount = utils.cast(int, data.attrib.get('viewCount', 0))
+
+    @cached_data_property
+    def fields(self):
+        return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def images(self):
+        return self.findItems(self._data, media.Image)
 
     def url(self, part):
         """ Returns the full url for something. Typically used for getting a specific image. """
@@ -394,40 +400,85 @@ class Movie(
         Playable._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
         self.audienceRatingImage = data.attrib.get('audienceRatingImage')
-        self.chapters = self.findItems(data, media.Chapter)
         self.chapterSource = data.attrib.get('chapterSource')
-        self.collections = self.findItems(data, media.Collection)
         self.contentRating = data.attrib.get('contentRating')
-        self.countries = self.findItems(data, media.Country)
-        self.directors = self.findItems(data, media.Director)
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.editionTitle = data.attrib.get('editionTitle')
         self.enableCreditsMarkerGeneration = utils.cast(int, data.attrib.get('enableCreditsMarkerGeneration', '-1'))
-        self.genres = self.findItems(data, media.Genre)
-        self.guids = self.findItems(data, media.Guid)
-        self.labels = self.findItems(data, media.Label)
         self.languageOverride = data.attrib.get('languageOverride')
-        self.markers = self.findItems(data, media.Marker)
-        self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.originalTitle = data.attrib.get('originalTitle')
         self.primaryExtraKey = data.attrib.get('primaryExtraKey')
-        self.producers = self.findItems(data, media.Producer)
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.ratingImage = data.attrib.get('ratingImage')
-        self.ratings = self.findItems(data, media.Rating)
-        self.roles = self.findItems(data, media.Role)
         self.slug = data.attrib.get('slug')
-        self.similar = self.findItems(data, media.Similar)
         self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.useOriginalTitle = utils.cast(int, data.attrib.get('useOriginalTitle', '-1'))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
-        self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def chapters(self):
+        return self.findItems(self._data, media.Chapter)
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def countries(self):
+        return self.findItems(self._data, media.Country)
+
+    @cached_data_property
+    def directors(self):
+        return self.findItems(self._data, media.Director)
+
+    @cached_data_property
+    def genres(self):
+        return self.findItems(self._data, media.Genre)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def markers(self):
+        return self.findItems(self._data, media.Marker)
+
+    @cached_data_property
+    def media(self):
+        return self.findItems(self._data, media.Media)
+
+    @cached_data_property
+    def producers(self):
+        return self.findItems(self._data, media.Producer)
+
+    @cached_data_property
+    def ratings(self):
+        return self.findItems(self._data, media.Rating)
+
+    @cached_data_property
+    def roles(self):
+        return self.findItems(self._data, media.Role)
+
+    @cached_data_property
+    def similar(self):
+        return self.findItems(self._data, media.Similar)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
+
+    @cached_data_property
+    def writers(self):
+        return self.findItems(self._data, media.Writer)
 
     @property
     def actors(self):
@@ -573,39 +624,66 @@ class Show(
         self.autoDeletionItemPolicyWatchedLibrary = utils.cast(
             int, data.attrib.get('autoDeletionItemPolicyWatchedLibrary', '0'))
         self.childCount = utils.cast(int, data.attrib.get('childCount'))
-        self.collections = self.findItems(data, media.Collection)
         self.contentRating = data.attrib.get('contentRating')
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.enableCreditsMarkerGeneration = utils.cast(int, data.attrib.get('enableCreditsMarkerGeneration', '-1'))
         self.episodeSort = utils.cast(int, data.attrib.get('episodeSort', '-1'))
         self.flattenSeasons = utils.cast(int, data.attrib.get('flattenSeasons', '-1'))
-        self.genres = self.findItems(data, media.Genre)
-        self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
-        self.labels = self.findItems(data, media.Label)
         self.languageOverride = data.attrib.get('languageOverride')
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
-        self.locations = self.listAttrs(data, 'path', etag='Location')
         self.network = data.attrib.get('network')
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.originalTitle = data.attrib.get('originalTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
-        self.ratings = self.findItems(data, media.Rating)
-        self.roles = self.findItems(data, media.Role)
         self.seasonCount = utils.cast(int, data.attrib.get('seasonCount', self.childCount))
         self.showOrdering = data.attrib.get('showOrdering')
-        self.similar = self.findItems(data, media.Similar)
         self.slug = data.attrib.get('slug')
         self.studio = data.attrib.get('studio')
         self.subtitleLanguage = data.attrib.get('subtitleLanguage', '')
         self.subtitleMode = utils.cast(int, data.attrib.get('subtitleMode', '-1'))
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.useOriginalTitle = utils.cast(int, data.attrib.get('useOriginalTitle', '-1'))
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def genres(self):
+        return self.findItems(self._data, media.Genre)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def locations(self):
+        return self.listAttrs(self._data, 'path', etag='Location')
+
+    @cached_data_property
+    def ratings(self):
+        return self.findItems(self._data, media.Rating)
+
+    @cached_data_property
+    def roles(self):
+        return self.findItems(self._data, media.Role)
+
+    @cached_data_property
+    def similar(self):
+        return self.findItems(self._data, media.Similar)
+
+    @cached_data_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     def __iter__(self):
         for season in self.seasons():
@@ -759,11 +837,8 @@ class Season(
         Video._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
         self.audioLanguage = data.attrib.get('audioLanguage', '')
-        self.collections = self.findItems(data, media.Collection)
-        self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
-        self.labels = self.findItems(data, media.Label)
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
         self.parentGuid = data.attrib.get('parentGuid')
         self.parentIndex = utils.cast(int, data.attrib.get('parentIndex'))
@@ -775,12 +850,30 @@ class Season(
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
-        self.ratings = self.findItems(data, media.Rating)
         self.subtitleLanguage = data.attrib.get('subtitleLanguage', '')
         self.subtitleMode = utils.cast(int, data.attrib.get('subtitleMode', '-1'))
-        self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_property
+    def ratings(self):
+        return self.findItems(self._data, media.Rating)
+
+    @cached_property
+    def ultraBlurColors(self):
+        return self.findItem(self._data, media.UltraBlurColors)
 
     def __iter__(self):
         for episode in self.episodes():
@@ -942,11 +1035,8 @@ class Episode(
         Playable._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
         self.audienceRatingImage = data.attrib.get('audienceRatingImage')
-        self.chapters = self.findItems(data, media.Chapter)
         self.chapterSource = data.attrib.get('chapterSource')
-        self.collections = self.findItems(data, media.Collection)
         self.contentRating = data.attrib.get('contentRating')
-        self.directors = self.findItems(data, media.Director)
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.grandparentArt = data.attrib.get('grandparentArt')
         self.grandparentGuid = data.attrib.get('grandparentGuid')
@@ -956,25 +1046,17 @@ class Episode(
         self.grandparentTheme = data.attrib.get('grandparentTheme')
         self.grandparentThumb = data.attrib.get('grandparentThumb')
         self.grandparentTitle = data.attrib.get('grandparentTitle')
-        self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
-        self.labels = self.findItems(data, media.Label)
-        self.markers = self.findItems(data, media.Marker)
-        self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.parentGuid = data.attrib.get('parentGuid')
         self.parentIndex = utils.cast(int, data.attrib.get('parentIndex'))
         self.parentTitle = data.attrib.get('parentTitle')
         self.parentYear = utils.cast(int, data.attrib.get('parentYear'))
-        self.producers = self.findItems(data, media.Producer)
         self.rating = utils.cast(float, data.attrib.get('rating'))
-        self.ratings = self.findItems(data, media.Rating)
-        self.roles = self.findItems(data, media.Role)
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
         self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.ultraBlurColors = self.findItem(data, media.UltraBlurColors)
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
-        self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))
 
         # If seasons are hidden, parentKey and parentRatingKey are missing from the XML response.
@@ -983,6 +1065,50 @@ class Episode(
         self._parentKey = data.attrib.get('parentKey')
         self._parentRatingKey = utils.cast(int, data.attrib.get('parentRatingKey'))
         self._parentThumb = data.attrib.get('parentThumb')
+
+    @cached_data_property
+    def chapters(self):
+        return self.findItems(self._data, media.Chapter)
+
+    @cached_data_property
+    def collections(self):
+        return self.findItems(self._data, media.Collection)
+
+    @cached_data_property
+    def directors(self):
+        return self.findItems(self._data, media.Director)
+
+    @cached_data_property
+    def guids(self):
+        return self.findItems(self._data, media.Guid)
+
+    @cached_data_property
+    def labels(self):
+        return self.findItems(self._data, media.Label)
+
+    @cached_data_property
+    def markers(self):
+        return self.findItems(self._data, media.Marker)
+
+    @cached_data_property
+    def media(self):
+        return self.findItems(self._data, media.Media)
+
+    @cached_data_property
+    def producers(self):
+        return self.findItems(self._data, media.Producer)
+
+    @cached_data_property
+    def ratings(self):
+        return self.findItems(self._data, media.Rating)
+
+    @cached_data_property
+    def roles(self):
+        return self.findItems(self._data, media.Role)
+
+    @cached_data_property
+    def writers(self):
+        return self.findItems(self._data, media.Writer)
 
     @cached_property
     def parentKey(self):
@@ -1149,12 +1275,10 @@ class Clip(
         """ Load attribute values from Plex XML response. """
         Video._loadData(self, data)
         Playable._loadData(self, data)
-        self._data = data
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.extraType = utils.cast(int, data.attrib.get('extraType'))
         self.index = utils.cast(int, data.attrib.get('index'))
-        self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(
             data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.skipDetails = utils.cast(int, data.attrib.get('skipDetails'))
@@ -1162,6 +1286,10 @@ class Clip(
         self.thumbAspectRatio = data.attrib.get('thumbAspectRatio')
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
+
+    @cached_data_property
+    def media(self):
+        return self.findItems(self._data, media.Media)
 
     @property
     def locations(self):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -48,7 +48,6 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        PlexObject._loadData(self, data)
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -855,23 +855,23 @@ class Season(
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
 
-    @cached_property
+    @cached_data_property
     def collections(self):
         return self.findItems(self._data, media.Collection)
 
-    @cached_property
+    @cached_data_property
     def guids(self):
         return self.findItems(self._data, media.Guid)
 
-    @cached_property
+    @cached_data_property
     def labels(self):
         return self.findItems(self._data, media.Label)
 
-    @cached_property
+    @cached_data_property
     def ratings(self):
         return self.findItems(self._data, media.Rating)
 
-    @cached_property
+    @cached_data_property
     def ultraBlurColors(self):
         return self.findItem(self._data, media.UltraBlurColors)
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -971,4 +971,4 @@ def test_library_section_cache_invalidation(movies):
     after_locations = movies.locations
     after_id = id(after_locations)
     assert before_id != after_id, "Locations should have a new object ID after a reload"
-    assert before_locations == after_locations, "Locations should not have changed content after a library reload"
+    assert str(before_locations) == str(after_locations), "Locations should not have changed content after a library reload"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -963,8 +963,6 @@ def test_library_multiedit_exceptions(music, artist, album, photos):
 
 def test_library_section_cache_invalidation(movies):
     # locations is one of the cached properties
-    with pytest.raises(KeyError):
-        movies.__dict__["locations"]
     before_locations = movies.locations
     before_id = id(before_locations)
     movies.reload()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -959,3 +959,18 @@ def test_library_multiedit_exceptions(music, artist, album, photos):
         music.batchMultiEdits(artist).editEdition("test")
     with pytest.raises(AttributeError):
         music.batchMultiEdits(album).addCountry("test")
+
+
+def test_library_section_cache_invalidation(movies):
+    # locations is one of the cached properties
+    with pytest.raises(KeyError):
+        movies.__dict__["locations"]
+    before_locations = movies.locations
+    before_id = id(before_locations)
+    movies.reload()
+    with pytest.raises(KeyError):
+        movies.__dict__["locations"]
+    after_locations = movies.locations
+    after_id = id(after_locations)
+    assert before_id != after_id, "Locations should have a new object ID after a reload"
+    assert before_locations == after_locations, "Locations should not have changed content after a library reload"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1540,3 +1540,18 @@ def test_video_Movie_matadataDirectory(movie):
     for art in movie.arts():
         if not art.ratingKey.startswith('http'):
             assert os.path.exists(os.path.join(utils.BOOTSTRAP_DATA_PATH, art.resourceFilepath))
+
+
+def test_video_cache_invalidation(movie):
+    # guids is one of the cached properties
+    with pytest.raises(KeyError):
+        movie.__dict__["guids"]
+    before_guids = movie.guids
+    before_id = id(before_guids)
+    movie.reload()
+    with pytest.raises(KeyError):
+        movie.__dict__["guids"]
+    after_guids = movie.guids
+    after_id = id(after_guids)
+    assert before_id != after_id, "GUIDs should have a new object ID after a reload"
+    assert before_guids == after_guids, "GUIDs should not have changed content after a reload"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -350,8 +350,8 @@ def test_video_Movie_reload_kwargs(movie):
     assert len(movie.media)
     assert movie.summary is not None
     movie.reload(includeFields=False, **movie._EXCLUDES)
-    assert movie.__dict__.get('media') == []
-    assert movie.__dict__.get('summary') is None
+    assert movie.media == []
+    assert movie.summary is None
 
 
 def test_video_movie_watched(movie):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1554,4 +1554,4 @@ def test_video_cache_invalidation(movie):
     after_guids = movie.guids
     after_id = id(after_guids)
     assert before_id != after_id, "GUIDs should have a new object ID after a reload"
-    assert before_guids == after_guids, "GUIDs should not have changed content after a reload"
+    assert str(before_guids) == str(after_guids), "GUIDs should not have changed content after a reload"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -350,8 +350,12 @@ def test_video_Movie_reload_kwargs(movie):
     assert len(movie.media)
     assert movie.summary is not None
     movie.reload(includeFields=False, **movie._EXCLUDES)
+    # Prevent auto reloading when using getattr on `media` and `summary`
+    original_auto_reload = movie._autoReload
+    movie._autoReload = False
     assert movie.media == []
     assert movie.summary is None
+    movie._autoReload = original_auto_reload
 
 
 def test_video_movie_watched(movie):


### PR DESCRIPTION
## Description

This PR introduces lazy loading for data attributes in all Plex objects as well as a caching mechanism when loading those attributes using a new `@cached_data_property` decorator. This change significantly improves performance by deferring the loading of computationally expensive attributes until when the user requests it.

The cache of properties created with `@cached_data_property` will also automatically be invalidated when `_loadData(...)` is called with a new XML data object.

Fixes: #1509 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable

## Additional Notes

The initial performance testing is very promising.  Below is a test script that was ran against the production python-plexapi package and this PR's version:

```py
import timeit

def test():
    from plexapi.server import PlexServer

    plex = PlexServer()

    res = []
    for section in plex.library.sections():
        items = section.all()
        res.extend([(i.title, i.lastViewedAt) for i in items])

if __name__ == "__main__":
    print(timeit.timeit(test, number=1))
```

In this testing scenario, the program does not need access to any of the expensive `Video` attributes (e.g. `images`, `genres`, `directors`). Since those expensive queries are skipped, the lazy-loaded testing results are ~3x faster than the production python-plexapi package.

```shell
# Time in seconds
Lazy-loaded: 5.732901584000501
Production: 17.07976305699958
```

Below are the Pyspy profiler outputs between the two packages against the above script:

**Lazy-loaded:**

![lazy-loaded](https://github.com/user-attachments/assets/771b34ca-8ca6-4dcc-beeb-d4c1cc357e86)

**Production:**

![production](https://github.com/user-attachments/assets/e483764a-a896-4f2c-a14e-8e2c81932012)

As can clearly be seen, python-plexapi (purple) is no longer the bottleneck, instead, the requests and urllib packages (which are making the HTTP requests to the Plex server) are the new bottlenecks.