### PR TITLE
Adopt PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,10 @@ description = "Python bindings for the Plex API."
 readme = "README.rst"
 requires-python = ">=3.9"
 keywords = ["plex", "api"]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD License",
 ]
 dependencies = ["requests"]
 dynamic = ["version"]
@@ -27,7 +26,7 @@ Documentation = "https://python-plexapi.readthedocs.io"
 version = {attr = "plexapi.const.__version__"}
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description
/CC @JonnyWong16 Followup to https://github.com/pushingkarmaorg/python-plexapi/pull/1484#discussion_r1909178917
Setuptools `v77` added full support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.

Metadata diff
```diff
 ...
-License: BSD-3-Clause
+License-Expression: BSD-3-Clause
 ...
-Classifier: License :: OSI Approved :: BSD License
 ...
```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
