### PR TITLE
Fix typo in `PlexSession` data attribute

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1016,15 +1016,15 @@ class PlexSession:
 
     @cached_data_property
     def player(self):
-        return self.findItem(self.data, etag='Player')
+        return self.findItem(self._data, etag='Player')
 
     @cached_data_property
     def session(self):
-        return self.findItem(self.data, etag='Session')
+        return self.findItem(self._data, etag='Session')
 
     @cached_data_property
     def transcodeSession(self):
-        return self.findItem(self.data, etag='TranscodeSession')
+        return self.findItem(self._data, etag='TranscodeSession')
 
     @property
     def players(self):


### PR DESCRIPTION
## Description

Fix typo in `PlexSession` `self._data` attribute.

Typo from #1510


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
