### PR TITLE
Fix CI PMS Docker image caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,9 +133,9 @@ jobs:
         echo "Digest: $digest"
         echo "digest=$digest" >> $GITHUB_OUTPUT
 
-    - name: Cache PMS Docker image
+    - name: Restore cached PMS Docker image
       id: docker-cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/.cache/docker/plexinc
         key: ${{ runner.os }}-docker-pms-${{ steps.docker-digest.outputs.digest }}
@@ -208,6 +208,12 @@ jobs:
         name: coverage-${{ matrix.plex }}-${{ steps.python.outputs.python-version }}
         path: .coverage
 
+    - name: Save PMS Docker image cache
+      if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.docker-cache.outputs.cache-primary-key }}
+        path: ~/.cache/docker/plexinc
 
   coverage:
     name: Process test coverage (${{ matrix.plex }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
           --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
           --header "Authorization: Bearer $token" \
           "https://registry-1.docker.io/v2/${{ env.PLEX_CONTAINER }}/manifests/${{ env.PLEX_CONTAINER_TAG }}" \
-          | jq -r '.config.digest')
+          | sha256sum | head -c 64)
         echo "Digest: $digest"
         echo "digest=$digest" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Docker manifest v2 doesn't provide the digest hash. It is just calculated as the SHA256 hash of the manifest.

Ref: https://stackoverflow.com/a/78711220

Also always cache the PMS Docker image even if the tests fail.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
