### PR TITLE
Various CI test fixes

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -881,7 +881,7 @@ def _test_library_search(library, obj):  # noqa: C901
             elif field.type == "date":
                 searchValue = searchValue.strftime("%Y-%m-%d")
                 _do_test_library_search(library, obj, field, operator, searchValue)
-                searchValue = "1s"
+                searchValue = "0s"
                 _do_test_library_search(library, obj, field, operator, searchValue)
 
 
@@ -889,7 +889,7 @@ def _do_test_library_search(library, obj, field, operator, searchValue):
     searchFilter = {field.key + operator.key[:-1]: searchValue}
     results = library.search(libtype=obj.type, filters=searchFilter)
 
-    if operator.key.startswith("!") or operator.key.startswith(">>") and (searchValue == 1 or searchValue == "1s"):
+    if operator.key.startswith("!") or operator.key.startswith(">>") and (searchValue == 1 or searchValue == "0s"):
         assert obj not in results
     else:
         assert obj in results, f"Unable to search {obj.type} by {field.key} using {operator.key} and value {searchValue}."

--- a/tests/test_playqueue.py
+++ b/tests/test_playqueue.py
@@ -4,6 +4,7 @@ from plexapi.playqueue import PlayQueue
 import pytest
 
 
+@pytest.mark.xfail(reason="Plex regression `playQueueTotalCount` value incorrect when item removed from PlayQueue")
 def test_create_playqueue(plex, show):
     # create the playlist
     episodes = show.episodes()

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -504,6 +504,7 @@ if __name__ == "__main__":  # noqa: C901
     if not opts.unclaimed and account and account.subscriptionActive:
         server.settings.get("GenerateIntroMarkerBehavior").set("never")
         server.settings.get("GenerateCreditsMarkerBehavior").set("never")
+        server.settings.get("GenerateAdMarkerBehavior").set("never")
         server.settings.get("GenerateVADBehavior").set("never")
         server.settings.get("MusicAnalysisBehavior").set("never")
     server.settings.get("GenerateBIFBehavior").set("never")


### PR DESCRIPTION
## Description

* Mark PlayQueue test as xfail. Plex regression: removing an item from a `PlayQueue` does not decrement the `playQueueTotalCount` number.
* Disable ad video markers detection on bootstrap test server.
* Change library search date tests from "last 1s" to "last 0s".


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
