### PR TITLE
Fix: Initialize sonos timeline cache timestamp

### DIFF
--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -66,6 +66,7 @@ class PlexSonosClient(PlexClient):
         self._proxyThroughServer = False
         self._showSecrets = CONFIG.get("log.show_secrets", "").lower() == "true"
         self._timeout = timeout or TIMEOUT
+        self._timeline_cache_timestamp = 0
 
     def playMedia(self, media, offset=0, **params):
 


### PR DESCRIPTION
## Description

`_timeline_cache_timestamp` is uninitalised in `PlexSonosClient`. I added a line that initilises it the same way the base `PlexClient` does.

Fixes #1523

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
