### PR TITLE
add support for fetching loudness levels of audio streams

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -433,9 +433,33 @@ class AudioStream(MediaPartStream):
         """
         return self._parent().setSelectedAudioStream(self)
 
+    def levels(self, subSample=128):
+        """ Load time series loudness levels.
+
+            Attributes:
+                subSample: (int): the number of loudness segments to load        
+        """
+
+        key = f'/library/streams/{self.id}/levels'
+        params = {'subsample': subSample}
+
+        levels = self.fetchItems(ekey=key, cls=Level, params=params)
+        return levels
+
     @deprecated('Use "setSelected" instead.')
     def setDefault(self):
         return self.setSelected()
+
+@utils.registerPlexObject
+class Level(PlexObject):
+    """ Represents an instance of loudness for an audio stream.
+
+        Attributes:
+            loudness (float): loudness level in db
+    """
+    def _loadData(self, data):  
+        """ Load attribute values from Plex XML response. """
+        self.loudness = data.attrib.get('v')
 
 
 @utils.registerPlexObject


### PR DESCRIPTION
## Description

This adds support for fetching loudness levels. This is used in Plexamp and Dash to show a waveform of the currently playing track.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable

I have not added tests (yet). Python is not my first language and I'm having a bit of trouble wrapping my head around how the test suite works.
