### PR TITLE
fix: acceptInvite deprecated 

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -558,20 +558,15 @@ class MyPlexAccount(PlexObject):
         return self.query(url, self._session.post, params=params)
 
     def acceptInvite(self, user):
-        """ Accept a pending friend invite from the specified user.
+        """Accept a pending invite.
 
-            Parameters:
-                user (:class:`~plexapi.myplex.MyPlexInvite` or str): :class:`~plexapi.myplex.MyPlexInvite`,
-                    username, or email of the friend invite to accept.
+        Parameters:
+            user (:class:`~plexapi.myplex.MyPlexInvite` | str): Invite object, username, or email.
         """
         invite = user if isinstance(user, MyPlexInvite) else self.pendingInvite(user, includeSent=False)
-        params = {
-            'friend': int(invite.friend),
-            'home': int(invite.home),
-            'server': int(invite.server)
-        }
-        url = MyPlexInvite.REQUESTS + f'/{invite.id}' + utils.joinArgs(params)
-        return self.query(url, self._session.put)
+
+        url = f"https://plex.tv/api/v2/shared_servers/{invite.id}/accept"
+        return self.query(url, self._session.post)
 
     def cancelInvite(self, user):
         """ Cancel a pending firend invite for the specified user.


### PR DESCRIPTION
## Description

`MyPlexAccount.acceptInvite` now targets Plex TV’s new v2 endpoint:

* Replaced the deprecated  
  `PUT https://plex.tv/api/invites/requests/{invite.id}`  
  with  
  `POST https://plex.tv/api/v2/shared_servers/{invite.id}/accept`.

This keeps the library working after Plex removed the old route.

Fixes #1536  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added or updated the docstring for new or existing methods  
- [ ] I have added tests when applicable  *(existing tests that cover `acceptInvite` still pass)*