### PR TITLE
Fix library image tests and system account test

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -32,8 +32,8 @@ def test_library_sectionByID_with_attrs(plex, movies):
     # This seems to fail for some reason.
     # my account allow of sync, didn't find any about settings about the library.
     # assert movies.allowSync is ("sync" in plex.ownerFeatures)
-    assert movies.art == "/:/resources/movie-fanart.jpg"
-    assert utils.is_metadata(
+    assert movies.art in ("/:/resources/movie-fanart.jpg", None)
+    assert movies.composite is None or utils.is_metadata(
         movies.composite, prefix="/library/sections/", contains="/composite/"
     )
     assert utils.is_datetime(movies.createdAt)
@@ -46,7 +46,7 @@ def test_library_sectionByID_with_attrs(plex, movies):
     assert movies.refreshing is False
     assert movies.scanner == "Plex Movie"
     assert movies._server._baseurl == utils.SERVER_BASEURL
-    assert movies.thumb == "/:/resources/movie.png"
+    assert movies.thumb in ("/:/resources/movie.png", None)
     assert movies.title == "Movies"
     assert movies.type == "movie"
     assert utils.is_datetime(movies.updatedAt)
@@ -561,13 +561,13 @@ def test_library_section_timeline(plex, movies):
     assert tl.TAG == "LibraryTimeline"
     assert tl.size > 0
     assert tl.allowSync is False
-    assert tl.art == "/:/resources/movie-fanart.jpg"
+    assert tl.art in ("/:/resources/movie-fanart.jpg", None)
     assert tl.content == "secondary"
     assert tl.identifier == "com.plexapp.plugins.library"
     assert datetime.fromtimestamp(tl.latestEntryTime).date() == datetime.today().date()
     assert tl.mediaTagPrefix == "/system/bundle/media/flags/"
     assert tl.mediaTagVersion > 1
-    assert tl.thumb == "/:/resources/movie.png"
+    assert tl.thumb in ("/:/resources/movie.png", None)
     assert tl.title1 == "Movies"
     assert utils.is_int(tl.updateQueueSize, gte=0)
     assert tl.viewGroup == "secondary"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -421,7 +421,7 @@ def test_server_system_accounts(plex):
     assert account.defaultSubtitleLanguage == "en"
     assert utils.is_int(account.id, gte=0)
     assert len(account.key)
-    assert len(account.name)
+    assert "" if account.id == 0 else len(account.name)
     assert account.subtitleMode == 0
     assert account.thumb == ""
     assert account.accountID == account.id


### PR DESCRIPTION
## Description

Fix library image tests and system account test

* Library artwork and thumbnail is no longer returned in the `/library/sections/all` XML data on newer versions of PMS.
* The default system account with ID == 0 has a blank name on newer versions of PMS.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
